### PR TITLE
Include GNUInstallDirs before CMAKE_INSTALL_* variables are used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   cd ${TRAVIS_BUILD_DIR}
   mkdir -p build
   cd build
-  cmake -DUNITTESTS=ON -DCOVERAGE=ON ..
+  cmake --warn-uninitialized -DUNITTESTS=ON -DCOVERAGE=ON ..
   make
   out/qdldl_tester
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ target_include_directories(qdldlobject PRIVATE ${PROJECT_SOURCE_DIR}/include)
 # Create Static Library
 # ----------------------------------------------
 
+include(GNUInstallDirs)
+
 # Static library
 add_library (qdldlstatic STATIC ${qdldl_src} ${qdldl_headers})
 # Give same name to static library output
@@ -109,8 +111,6 @@ target_include_directories(qdldlstatic
 
 # Install Static Library
 # ----------------------------------------------
-
-include(GNUInstallDirs)
 
 install(TARGETS qdldlstatic
         EXPORT  ${PROJECT_NAME}


### PR DESCRIPTION
The install `qdldl::qdldlstatic` target is currently broken since `CMAKE_INSTALL_INCLUDEDIR` is used before it is defined (by including the `GNUInstallDirs` module) when setting the `INTERFACE_INCLUDE_DIRECTORIES`.