### PR TITLE
reduce memory access in linear solve loop

### DIFF
--- a/src/qdldl.c
+++ b/src/qdldl.c
@@ -239,11 +239,12 @@ void QDLDL_Lsolve(const QDLDL_int    n,
                   const QDLDL_float* Lx,
                   QDLDL_float* x){
 
-QDLDL_int i,j;
+  QDLDL_int i,j;
   for(i = 0; i < n; i++){
-      for(j = Lp[i]; j < Lp[i+1]; j++){
-          x[Li[j]] -= Lx[j]*x[i];
-      }
+    QDLDL_float val = x[i];
+    for(j = Lp[i]; j < Lp[i+1]; j++){
+      x[Li[j]] -= Lx[j]*val;
+    }
   }
 }
 
@@ -254,11 +255,13 @@ void QDLDL_Ltsolve(const QDLDL_int    n,
                    const QDLDL_float* Lx,
                    QDLDL_float* x){
 
-QDLDL_int i,j;
+  QDLDL_int i,j;
   for(i = n-1; i>=0; i--){
-      for(j = Lp[i]; j < Lp[i+1]; j++){
-          x[i] -= Lx[j]*x[Li[j]];
-      }
+    QDLDL_float val = x[i];
+    for(j = Lp[i]; j < Lp[i+1]; j++){
+      val -= Lx[j]*x[Li[j]];
+    }
+    x[i] = val;
   }
 }
 
@@ -270,10 +273,9 @@ void QDLDL_solve(const QDLDL_int       n,
                     const QDLDL_float* Dinv,
                     QDLDL_float* x){
 
-QDLDL_int i;
+  QDLDL_int i;
 
-QDLDL_Lsolve(n,Lp,Li,Lx,x);
-for(i = 0; i < n; i++) x[i] *= Dinv[i];
-QDLDL_Ltsolve(n,Lp,Li,Lx,x);
-
+  QDLDL_Lsolve(n,Lp,Li,Lx,x);
+  for(i = 0; i < n; i++) x[i] *= Dinv[i];
+  QDLDL_Ltsolve(n,Lp,Li,Lx,x);
 }


### PR DESCRIPTION
By defining this temp variable we use that fact that `i` is never equal to `Li[j]`. Compiler does not have this information.

binary code for the loop changes from
```assembly
        movsx   rdi, DWORD PTR [rdx+rax*4]
        vmovss  xmm0, DWORD PTR [rcx+rax*4]
        add     rax, 1
        lea     rdi, [r8+rdi*4]
        vmovss  xmm1, DWORD PTR [rdi]
        vfnmadd132ss    xmm0, xmm1, DWORD PTR [r9]
        vmovss  DWORD PTR [rdi], xmm0
```

to

```assembly
        movsx   rdi, DWORD PTR [rdx+rax*4]
        vmovss  xmm0, DWORD PTR [rcx+rax*4]
        add     rax, 1
        lea     rdi, [r8+rdi*4]
        vfnmadd213ss    xmm0, xmm1, DWORD PTR [rdi]
        vmovss  DWORD PTR [rdi], xmm0
```

notice the drop of the first `vmovss` by the compiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oxfordcontrol/qdldl/30)
<!-- Reviewable:end -->
