### PR TITLE
Gate the library products behind CMake flags and some CMake cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   cd ${TRAVIS_BUILD_DIR}
   mkdir -p build
   cd build
-  cmake --warn-uninitialized -DUNITTESTS=ON -DCOVERAGE=ON ..
+  cmake --warn-uninitialized -DQDLDL_UNITTESTS=ON -DCOVERAGE=ON ..
   make
   out/qdldl_tester
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,10 @@ cmake_dependent_option( QDLDL_BUILD_DEMO_EXE
                         ON    # Default to on
                         QDLDL_BUILD_STATIC_LIB OFF ) # Force off if the static library isn't built
 
-option( QDLDL_UNITTESTS "Build the unit testing suite" OFF )
+cmake_dependent_option( QDLDL_UNITTESTS
+                        "Build the unit testing suite"
+                        OFF    # Default to off
+                        QDLDL_BUILD_STATIC_LIB OFF ) # Force off if the static library isn't built
 
 # Set the output folder where your program will be created
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/out)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Options
 # ----------------------------------------------
 # Use floats instead of doubles
-set(DFLOAT OFF CACHE BOOL "Use float numbers instead of doubles")
+option( DFLOAT "Use float numbers instead of doubles" OFF )
 message(STATUS "Floats are ${DFLOAT}")
 
 # Use long integers for indexing
-set(DLONG ON CACHE BOOL "Use long integers (64bit) for indexing")
-if (NOT (CMAKE_SIZEOF_VOID_P EQUAL 8))
+option( DLONG "Use long integers (64bit) for indexing" ON )
+
+if( NOT (CMAKE_SIZEOF_VOID_P EQUAL 8) )
 	message(STATUS "Disabling long integers (64bit) on 32bit machine")
 	set(DLONG OFF)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,9 @@ target_include_directories(qdldlobject PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
 include(GNUInstallDirs)
 
-if( QDLDL_BUILD_STATIC_LIB )
-    message( STATUS "Configuring static library" )
+message( STATUS "Static library build is ${QDLDL_BUILD_STATIC_LIB}" )
 
+if( QDLDL_BUILD_STATIC_LIB )
     # Static library
     add_library (qdldlstatic STATIC ${qdldl_src} ${qdldl_headers})
     # Give same name to static library output
@@ -146,8 +146,6 @@ if( QDLDL_BUILD_STATIC_LIB )
             ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
-else()
-    message( STATUS "Not building static library" )
 endif()
 
 # Install Headers
@@ -158,9 +156,9 @@ install(FILES ${qdldl_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/qdldl")
 # Install Shared Library
 # ----------------------------------------------
 # Create qdldl shared library
-if( QDLDL_BUILD_SHARED_LIB )
-    message( STATUS "Configuring shared library" )
+message( STATUS "Shared library build is ${QDLDL_BUILD_SHARED_LIB}" )
 
+if( QDLDL_BUILD_SHARED_LIB )
     add_library (qdldl SHARED ${qdldl_src} ${qdldl_headers})
 
     # Declare include directories for the cmake exported target
@@ -174,13 +172,11 @@ if( QDLDL_BUILD_SHARED_LIB )
     	LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     	ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     	RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
-else()
-    message( STATUS "Not building shared library" )
 endif()
 
-if( QDLDL_BUILD_DEMO_EXE )
-    message( STATUS "Configuring demo executable" )
+message( STATUS "Demo executable build is ${QDLDL_BUILD_DEMO_EXE}" )
 
+if( QDLDL_BUILD_DEMO_EXE )
     # Create demo executable (linked to static library)
     add_executable (qdldl_example ${PROJECT_SOURCE_DIR}/examples/example.c)
     target_link_libraries (qdldl_example qdldlstatic)
@@ -238,9 +234,9 @@ endif()
 # Add testing
 # ----------------------------------------------
 # Add custom command to generate tests
-if( QDLDL_UNITTESTS )
-    message( STATUS "Configuring unit testing suite" )
+message( STATUS "Unit testing suite build is ${QDLDL_UNITTESTS}" )
 
+if( QDLDL_UNITTESTS )
     # Add test_headers and codegen_test_headers
     add_subdirectory(tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ cmake_dependent_option( QDLDL_BUILD_DEMO_EXE
                         ON    # Default to on
                         QDLDL_BUILD_STATIC_LIB OFF ) # Force off if the static library isn't built
 
+option( QDLDL_UNITTESTS "Build the unit testing suite" OFF )
 
 # Set the output folder where your program will be created
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/out)
@@ -236,7 +237,8 @@ endif()
 # Add testing
 # ----------------------------------------------
 # Add custom command to generate tests
-if (UNITTESTS)
+if( QDLDL_UNITTESTS )
+    message( STATUS "Configuring unit testing suite" )
 
     # Add test_headers and codegen_test_headers
     add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,10 @@ if (NOT MSVC)
 
     if (COVERAGE)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-	if(FORTRAN)
-		set(CMAKE_FORTRAN_FLAGS "${CMAKE_FORTRAN_FLAGS} --coverage")
-	endif(FORTRAN)
+
+	      if(FORTRAN)
+		        set(CMAKE_FORTRAN_FLAGS "${CMAKE_FORTRAN_FLAGS} --coverage")
+	      endif(FORTRAN)
     endif()
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
@@ -230,7 +231,6 @@ if( QDLDL_BUILD_SHARED_LIB OR QDLDL_BUILD_STATIC_LIB)
             COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
     endif()
 endif()
-
 
 
 # Add testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,16 @@ set(QDLDL_VERSION "${QDLDL_VERSION_MAJOR}.${QDLDL_VERSION_MINOR}.${QDLDL_VERSION
 # Project name
 project(qdldl VERSION ${QDLDL_VERSION})
 
+include( CMakeDependentOption )
+
+option( QDLDL_BUILD_STATIC_LIB "Build the static library" ON )
+option( QDLDL_BUILD_SHARED_LIB "Build the shared library" ON )
+
+cmake_dependent_option( QDLDL_BUILD_DEMO_EXE
+                        "Build the demo executable (requires the static library)"
+                        ON    # Default to on
+                        QDLDL_BUILD_STATIC_LIB OFF ) # Force off if the static library isn't built
+
 
 # Set the output folder where your program will be created
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/out)
@@ -112,25 +122,30 @@ target_include_directories(qdldlobject PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
 include(GNUInstallDirs)
 
-# Static library
-add_library (qdldlstatic STATIC ${qdldl_src} ${qdldl_headers})
-# Give same name to static library output
-set_target_properties(qdldlstatic PROPERTIES OUTPUT_NAME qdldl)
+if( QDLDL_BUILD_STATIC_LIB )
+    message( STATUS "Configuring static library" )
 
-# Declare include directories for the cmake exported target
-target_include_directories(qdldlstatic
-                           PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                                  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/qdldl>")
+    # Static library
+    add_library (qdldlstatic STATIC ${qdldl_src} ${qdldl_headers})
+    # Give same name to static library output
+    set_target_properties(qdldlstatic PROPERTIES OUTPUT_NAME qdldl)
 
-# Install Static Library
-# ----------------------------------------------
+    # Declare include directories for the cmake exported target
+    target_include_directories(qdldlstatic
+                               PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                      "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/qdldl>")
 
-install(TARGETS qdldlstatic
-        EXPORT  ${PROJECT_NAME}
-        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    # Install Static Library
+    # ----------------------------------------------
 
+    install(TARGETS qdldlstatic
+            EXPORT  ${PROJECT_NAME}
+            ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
+else()
+    message( STATUS "Not building static library" )
+endif()
 
 # Install Headers
 # ----------------------------------------------
@@ -140,69 +155,80 @@ install(FILES ${qdldl_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/qdldl")
 # Install Shared Library
 # ----------------------------------------------
 # Create qdldl shared library
-add_library (qdldl SHARED ${qdldl_src} ${qdldl_headers})
+if( QDLDL_BUILD_SHARED_LIB )
+    message( STATUS "Configuring shared library" )
 
-# Declare include directories for the cmake exported target
-target_include_directories(qdldl
-	PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-	"$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/qdldl>")
+    add_library (qdldl SHARED ${qdldl_src} ${qdldl_headers})
 
-# Install qdldl shared library
-install(TARGETS qdldl
-	EXPORT  ${PROJECT_NAME}
-	LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-	ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-	RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    # Declare include directories for the cmake exported target
+    target_include_directories(qdldl
+    	PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    	"$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/qdldl>")
 
-# Create demo executable (linked to static library)
-add_executable (qdldl_example ${PROJECT_SOURCE_DIR}/examples/example.c)
-target_link_libraries (qdldl_example qdldlstatic)
+    # Install qdldl shared library
+    install(TARGETS qdldl
+    	EXPORT  ${PROJECT_NAME}
+    	LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    	ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    	RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
+else()
+    message( STATUS "Not building shared library" )
+endif()
 
+if( QDLDL_BUILD_DEMO_EXE )
+    message( STATUS "Configuring demo executable" )
+
+    # Create demo executable (linked to static library)
+    add_executable (qdldl_example ${PROJECT_SOURCE_DIR}/examples/example.c)
+    target_link_libraries (qdldl_example qdldlstatic)
+else()
+    message( STATUS "Not building demo executable" )
+endif()
 
 # Create CMake packages for the build directory
 # ----------------------------------------------
-include(CMakePackageConfigHelpers)
+if( QDLDL_BUILD_SHARED_LIB OR QDLDL_BUILD_STATIC_LIB)
+    include(CMakePackageConfigHelpers)
 
-write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/qdldl-config-version.cmake"
-  VERSION ${QDLDL_VERSION}
-  COMPATIBILITY SameMajorVersion
-)
+    write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/qdldl-config-version.cmake"
+      VERSION ${QDLDL_VERSION}
+      COMPATIBILITY SameMajorVersion
+    )
 
-export(EXPORT ${PROJECT_NAME}
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/qdldl-targets.cmake"
-  NAMESPACE qdldl::)
+    export(EXPORT ${PROJECT_NAME}
+      FILE "${CMAKE_CURRENT_BINARY_DIR}/qdldl-targets.cmake"
+      NAMESPACE qdldl::)
 
-if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config.cmake)
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config.cmake "include(\"\${CMAKE_CURRENT_LIST_DIR}/qdldl-targets.cmake\")\n")
-endif()
-
-
-# Create CMake packages for the install directory
-# ----------------------------------------------
-
-set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/qdldl)
-
-install(EXPORT ${PROJECT_NAME}
-        FILE qdldl-targets.cmake
-        NAMESPACE qdldl::
-        DESTINATION ${ConfigPackageLocation})
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config-version.cmake
-        DESTINATION ${ConfigPackageLocation})
+    if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config.cmake)
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config.cmake "include(\"\${CMAKE_CURRENT_LIST_DIR}/qdldl-targets.cmake\")\n")
+    endif()
 
 
+    # Create CMake packages for the install directory
+    # ----------------------------------------------
 
-# Add uninstall command
-# ----------------------------------------------
-if(NOT TARGET uninstall)
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/configure/cmake/cmake_uninstall.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-        IMMEDIATE @ONLY)
+    set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/qdldl)
 
-    add_custom_target(uninstall
-        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    install(EXPORT ${PROJECT_NAME}
+            FILE qdldl-targets.cmake
+            NAMESPACE qdldl::
+            DESTINATION ${ConfigPackageLocation})
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config.cmake
+                  ${CMAKE_CURRENT_BINARY_DIR}/qdldl-config-version.cmake
+            DESTINATION ${ConfigPackageLocation})
+
+    # Add uninstall command
+    # ----------------------------------------------
+    if(NOT TARGET uninstall)
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/configure/cmake/cmake_uninstall.cmake.in"
+            "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+            IMMEDIATE @ONLY)
+
+        add_custom_target(uninstall
+            COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    endif()
 endif()
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ test_script:
 - cd "%APPVEYOR_BUILD_FOLDER%"
 - mkdir build
 - cd build
-- cmake -G "%CMAKE_PROJECT%" -DUNITTESTS=ON ..
+- cmake -G "%CMAKE_PROJECT%" -DQDLDL_UNITTESTS=ON ..
 - cmake --build .
 - call "%APPVEYOR_BUILD_FOLDER%\build\out\Debug\qdldl_tester.exe"
 


### PR DESCRIPTION
When QDLDL is included in OSQP, only the object library is used and the libraries and executables can actually pose issues when compiling for embedded targets.

Also, cleanup the CMake file a little bit by exposing the other compile options using the CMake `option` command instead of directly setting the cache (since `option` will allow IDEs to see that they are options that the user can change/modify).

Also change the CMake variable that the unit tests are gated on to be unique to this project.